### PR TITLE
Fixed "setState on unmounted component"

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ export class ProgressiveImage extends React.Component<ProgressiveImageProps, Pro
             .then(srcDataURI => !this.unmounted && this.setState({ src: srcDataURI, blur: 0 }));
     }
 
-    componentWillUnMount() {
+    componentWillUnmount() {
         this.unmounted = true;
     }
 


### PR DESCRIPTION
Although an unmount mechanism is implemented, we still get the "setState on unmounted component" error.
We have managed to find the problem lying in a typo of the lifecycle method name.
Instead of "componentWillUnMount" it should be "componentWillUnmount".

With this, the error disappears.